### PR TITLE
support raw binary fields

### DIFF
--- a/packages/bytable-client/package-lock.json
+++ b/packages/bytable-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bytable-client",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bytable-client/src/Codec.ts
+++ b/packages/bytable-client/src/Codec.ts
@@ -1,6 +1,13 @@
 import { DataViewReader } from './DataViewReader';
 import { DataViewWriter } from './DataViewWriter';
 
+/**
+ * Codec is responsible for reading data from binary and constructing js objects
+ * or writing js objects data into binary format.
+ * 
+ * Please use `Codec.create(C)` instead of `new Codec(C)` since it's more effecient.
+ * It will create a new instance or pull one from the cache if it was alread created before and still available.
+ */
 export class Codec<T> { 
     private readonly reader: DataViewReader<T>;
     private readonly writer: DataViewWriter<T>;
@@ -10,11 +17,33 @@ export class Codec<T> {
         this.writer = new DataViewWriter(C);
     }
 
-    read(msg: ArrayBuffer): T {
-        return this.reader.read(new DataView(msg)) as any;
+    /**
+     * Reads data from array buffer into js object.
+     * @param buf 
+     */
+    read(buf: ArrayBuffer): T {
+        return this.reader.read(new DataView(buf)) as T;
     }
 
+    /**
+     * Writes js object data into array buffer.
+     * @param {T} obj - js object.
+     */
     write(obj: T): ArrayBuffer {
         return this.writer.write(obj).buffer;
+    }
+
+    // Static
+    private static types: WeakMap<any, any> = new WeakMap();
+
+    /**
+     * Creates a new instance of the Codec or pulls from existed.
+     * @param C - class type.
+     */
+    public static create<K>(C: { new(): K }) {
+        if(!this.types.has(C)) {
+            this.types.set(C, new Codec(C));
+        }
+        return this.types.get(C);
     }
 }

--- a/packages/bytable-client/src/Codec.ts
+++ b/packages/bytable-client/src/Codec.ts
@@ -5,7 +5,7 @@ import { DataViewWriter } from './DataViewWriter';
  * Responsible for reading binary data and constructing js objects.
  * 
  * `Codec.create(C)` is more preferable to use over `new Codec(C)`.
- * It will create a new instance or pull one from the cache.
+ * It will create a new instance or pull one from cache.
  */
 export class Codec<T> { 
     private readonly reader: DataViewReader<T>;
@@ -32,11 +32,11 @@ export class Codec<T> {
         return this.writer.write(obj).buffer;
     }
 
-    // Static
+    // Cache of codec instances by class type.
     private static types: WeakMap<any, any> = new WeakMap();
 
     /**
-     * Creates a new instance of the Codec or pulls from existed.
+     * Creates a new instance of the Codec or pulls from cache.
      * @param C - class type.
      */
     public static create<K>(C: { new(): K }) {

--- a/packages/bytable-client/src/Codec.ts
+++ b/packages/bytable-client/src/Codec.ts
@@ -2,7 +2,7 @@ import { DataViewReader } from './DataViewReader';
 import { DataViewWriter } from './DataViewWriter';
 
 /**
- * Responsible for reading data from/to binary and constructing js objects.
+ * Responsible for reading binary data and constructing js objects.
  * 
  * `Codec.create(C)` is more preferable to use over `new Codec(C)`.
  * It will create a new instance or pull one from the cache if it's alread created.

--- a/packages/bytable-client/src/Codec.ts
+++ b/packages/bytable-client/src/Codec.ts
@@ -5,7 +5,7 @@ import { DataViewWriter } from './DataViewWriter';
  * Responsible for reading binary data and constructing js objects.
  * 
  * `Codec.create(C)` is more preferable to use over `new Codec(C)`.
- * It will create a new instance or pull one from the cache if it's alread created.
+ * It will create a new instance or pull one from the cache.
  */
 export class Codec<T> { 
     private readonly reader: DataViewReader<T>;

--- a/packages/bytable-client/src/Codec.ts
+++ b/packages/bytable-client/src/Codec.ts
@@ -2,11 +2,10 @@ import { DataViewReader } from './DataViewReader';
 import { DataViewWriter } from './DataViewWriter';
 
 /**
- * Codec is responsible for reading data from binary and constructing js objects
- * or writing js objects data into binary format.
+ * Responsible for reading data from/to binary and constructing js objects.
  * 
- * Please use `Codec.create(C)` instead of `new Codec(C)` since it's more effecient.
- * It will create a new instance or pull one from the cache if it was alread created before and still available.
+ * `Codec.create(C)` is more preferable to use over `new Codec(C)`.
+ * It will create a new instance or pull one from the cache if it's alread created.
  */
 export class Codec<T> { 
     private readonly reader: DataViewReader<T>;

--- a/packages/bytable-client/src/DataViewReader.ts
+++ b/packages/bytable-client/src/DataViewReader.ts
@@ -4,22 +4,27 @@ import { bson } from './core';
 
 export class DataViewReader<C> extends Reader<C, DataView> {
     readAs<T>(msg: DataView, type: string, offset: number, size: number): T {
-        if(byteMap.has(type)) {
-            switch(type){
-                case 'UInt8':       return msg.getUint8(offset) as any;
-                case 'UInt16BE':    return msg.getUint16(offset) as any;
-                case 'UInt32BE':    return msg.getUint32(offset) as any;
-                case 'Int8':        return msg.getInt8(offset) as any;
-                case 'Int16BE':     return msg.getInt16(offset) as any;
-                case 'Int32BE':     return msg.getInt32(offset) as any;
-                case 'FloatBE':     return msg.getFloat32(offset) as any;
-                case 'DoubleBE':    return msg.getFloat64(offset) as any;
-            }
+        // Static Types
+        switch(type) {
+            case 'UInt8':       return msg.getUint8(offset) as any;
+            case 'UInt16BE':    return msg.getUint16(offset) as any;
+            case 'UInt32BE':    return msg.getUint32(offset) as any;
+            case 'Int8':        return msg.getInt8(offset) as any;
+            case 'Int16BE':     return msg.getInt16(offset) as any;
+            case 'Int32BE':     return msg.getInt32(offset) as any;
+            case 'FloatBE':     return msg.getFloat32(offset) as any;
+            case 'DoubleBE':    return msg.getFloat64(offset) as any;
         }
-        const buf = msg.buffer.slice(offset, offset + size);
-        if (type === 'BSON') {
-            return bson.deserialize(Buffer.from(buf));
+
+        // Dynamic Types
+        const buf: Buffer = Buffer.from(msg.buffer, offset, size);
+        switch(type) {
+            case 'BSON':        return bson.deserialize(buf);
+            case 'Binary':      return buf.buffer as any;
+            case 'String':      return buf.toString('UTF8') as any;
         }
-        return Buffer.from(buf).toString('UTF8') as any;
+
+        // Everything else
+        throw new Error(`Unknown type ${type}`);
     }
 }

--- a/packages/bytable-client/src/DataViewReader.ts
+++ b/packages/bytable-client/src/DataViewReader.ts
@@ -20,7 +20,7 @@ export class DataViewReader<C> extends Reader<C, DataView> {
         const buf: Buffer = Buffer.from(msg.buffer, offset, size);
         switch(type) {
             case 'BSON':        return bson.deserialize(buf);
-            case 'Binary':      return buf.buffer as any;
+            case 'Binary':      return buf.buffer.slice(offset, offset + size) as any;
             case 'String':      return buf.toString('UTF8') as any;
         }
 

--- a/packages/bytable-client/src/DataViewWriter.ts
+++ b/packages/bytable-client/src/DataViewWriter.ts
@@ -8,13 +8,16 @@ export class DataViewWriter<T> extends Writer<T, DataView> {
     }
 
     protected dynamicToBinary(type: string, value: any): any {
-        if(type === 'BSON')     return bson.serialize(value);
-        if(type === 'String')   return Buffer.from(value as string, 'UTF8');
-        return null;
+        if (type === 'BSON')    return bson.serialize(value);
+        if (type === 'String')  return Buffer.from(value as string, 'UTF8');
+
+        // Everything else
+        throw new Error(`Unknown type ${type}.`);
     }
 
     protected writeAs(msg: DataView, type: string, value: any, offset: number): any {
-        switch(type){
+        // Static Types
+        switch(type) {
             case 'UInt8':       return msg.setUint8(offset, value) as any;
             case 'UInt16BE':    return msg.setUint16(offset, value) as any;
             case 'UInt32BE':    return msg.setUint32(offset, value) as any;
@@ -24,7 +27,12 @@ export class DataViewWriter<T> extends Writer<T, DataView> {
             case 'FloatBE':     return msg.setFloat32(offset, value) as any;
             case 'DoubleBE':    return msg.setFloat64(offset, value) as any;
         }
-        if(type === 'binary')   return Buffer.from(msg.buffer as any).fill(value, offset).buffer;
-        else                    throw new Error(`Unknown type ${type}.`);
+
+        // Binary of Dynamic Types
+        const buf: Buffer = Buffer.from(msg.buffer);
+        if (type === 'binary' || type === 'Binary') return buf.fill(value, offset).buffer;
+
+        // Everything else
+        throw new Error(`Unknown type ${type}.`);
     }
 }

--- a/packages/bytable-client/src/DataViewWriter.ts
+++ b/packages/bytable-client/src/DataViewWriter.ts
@@ -12,7 +12,7 @@ export class DataViewWriter<T> extends Writer<T, DataView> {
         switch (type) {
             case 'BSON':        return bson.serialize(value);
             case 'String':      return Buffer.from(value as string, 'UTF8');
-            case 'Binary':      return value;
+            case 'Binary':      return Buffer.from(value as ArrayBuffer);
         }
 
         // Everything else

--- a/packages/bytable-client/src/DataViewWriter.ts
+++ b/packages/bytable-client/src/DataViewWriter.ts
@@ -8,8 +8,12 @@ export class DataViewWriter<T> extends Writer<T, DataView> {
     }
 
     protected dynamicToBinary(type: string, value: any): any {
-        if (type === 'BSON')    return bson.serialize(value);
-        if (type === 'String')  return Buffer.from(value as string, 'UTF8');
+        // TODO: investigate why return type should be Buffer, but not ArrayBuffer!!!
+        switch (type) {
+            case 'BSON':        return bson.serialize(value);
+            case 'String':      return Buffer.from(value as string, 'UTF8');
+            case 'Binary':      return value;
+        }
 
         // Everything else
         throw new Error(`Unknown type ${type}.`);
@@ -30,7 +34,7 @@ export class DataViewWriter<T> extends Writer<T, DataView> {
 
         // Binary of Dynamic Types
         const buf: Buffer = Buffer.from(msg.buffer);
-        if (type === 'binary' || type === 'Binary') return buf.fill(value, offset).buffer;
+        if (type === 'binary') return buf.fill(value, offset).buffer;
 
         // Everything else
         throw new Error(`Unknown type ${type}.`);

--- a/packages/bytable-client/test/e2e.spec.ts
+++ b/packages/bytable-client/test/e2e.spec.ts
@@ -1,5 +1,6 @@
+import { Buffer } from 'buffer';
 import { expect, assert } from 'chai';
-import { proto, i8, u8 } from 'bytable';
+import { proto, i8, u8, u16, string, binary, b } from 'bytable';
 import { Codec } from '../src';
 
 describe('e2e', () => {
@@ -62,6 +63,43 @@ describe('e2e', () => {
             foo.bar2 = 7;
             const buf = foo.write();
             const foo2 = Foo.read(buf);
+            expect(foo.bar).to.eq(foo2.bar);
+            expect(foo.positive).to.eq(foo2.positive);
+        });
+    });
+
+    describe('embedding binary data', () => {
+        @proto
+        class Doc {
+            @string header: string;
+            @string content: string;
+            @u16 pages: number;
+            @b foo: ArrayBuffer;
+
+            public write = () => Codec.create(Doc).write(this);
+            public static read = (buf: ArrayBuffer): Doc => Codec.create(Doc).read(buf);
+        }
+
+        it('should read Doc and embedded Foo', () => {
+            const foo = new Foo();
+            foo.bar = -12;
+            foo.positive = 12;
+
+            const fooBuf = foo.write();
+
+            const doc = new Doc();
+            doc.header = 'Notice';
+            doc.content = 'To be or not to be';
+            doc.pages = 256;
+            doc.foo = fooBuf;
+
+            const docBuf = doc.write();
+            const doc2 = Doc.read(docBuf);
+            expect(doc.header).to.eq(doc2.header);
+            expect(doc.content).to.eq(doc2.content);
+            expect(doc.pages).to.eq(doc2.pages);
+
+            const foo2 = Foo.read(doc2.foo);
             expect(foo.bar).to.eq(foo2.bar);
             expect(foo.positive).to.eq(foo2.positive);
         });

--- a/packages/bytable-client/test/e2e.spec.ts
+++ b/packages/bytable-client/test/e2e.spec.ts
@@ -1,0 +1,69 @@
+import { expect, assert } from 'chai';
+import { proto, i8, u8 } from 'bytable';
+import { Codec } from '../src';
+
+describe('e2e', () => {
+    @proto
+    class Foo {
+        @i8 bar: number;
+        @u8 positive: number;
+
+        public write = () => Codec.create(Foo).write(this);
+        public static read = (buf: ArrayBuffer): Foo => Codec.create(Foo).read(buf);
+    }
+
+    describe('read/write methods', () => {
+        it('should handle static types', () => {
+            const foo = new Foo();
+            foo.bar = -42;
+            foo.positive = 12;
+            const buf = foo.write();
+            const foo2 = Foo.read(buf);
+            expect(foo.bar).to.eq(foo2.bar);
+            expect(foo.positive).to.eq(foo2.positive);
+        });
+
+        it('should handle static types', () => {
+            const foo = new Foo();
+            foo.bar = -12;
+            foo.positive = 42;
+            const buf = foo.write();
+            const foo2 = Foo.read(buf);
+            expect(foo.bar).to.eq(foo2.bar);
+            expect(foo.positive).to.eq(foo2.positive);
+        });
+    });
+
+    describe('extends another class', () => {
+        @proto
+        class Foo2 extends Foo {
+            @i8 bar2: number;
+
+            public write = () => Codec.create(Foo2).write(this);
+            public static read = (buf: ArrayBuffer): Foo2 => Codec.create(Foo2).read(buf);
+        }
+
+        it('should read Foo members and Foo2 members', () => {
+            const foo = new Foo2();
+            foo.bar = -42;
+            foo.positive = 12;
+            foo.bar2 = 7;
+            const buf = foo.write();
+            const foo2 = Foo2.read(buf);
+            expect(foo.bar).to.eq(foo2.bar);
+            expect(foo.positive).to.eq(foo2.positive);
+            expect(foo.bar2).to.eq(foo2.bar2);
+        });
+
+        it('should be able to cast to Foo', () => {
+            const foo = new Foo2();
+            foo.bar = -42;
+            foo.positive = 12;
+            foo.bar2 = 7;
+            const buf = foo.write();
+            const foo2 = Foo.read(buf);
+            expect(foo.bar).to.eq(foo2.bar);
+            expect(foo.positive).to.eq(foo2.positive);
+        });
+    });
+});

--- a/packages/bytable-node/package-lock.json
+++ b/packages/bytable-node/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bytable-node",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bytable/package-lock.json
+++ b/packages/bytable/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bytable",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bytable/src/byte-table-builder.ts
+++ b/packages/bytable/src/byte-table-builder.ts
@@ -70,7 +70,7 @@ export function toBinary(
         const [ fieldName, type, dynamic ] = protoTable[n];
         if (dynamic) {
             const binary = dynamicToBinary(dynamic, obj[fieldName]);
-            const dynamicSize = type !== 'Binary' ? binary.byteLength: binary.length;
+            const dynamicSize = binary.byteLength || binary.length;
             table[n] = [ BINARY, dynamicSize, binary ];
 
             // Find companion field and write binary size.


### PR DESCRIPTION
binary fields are important because:
1) you can do embedding, i.e. one class into another class' field;
2) for bson in a field